### PR TITLE
Add unit tests for macros

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1,0 +1,110 @@
+name: pr_tests
+
+on:
+  pull_request:
+    branches:
+      - main
+      - 'release/**'
+
+concurrency: dbt_integration_tests
+
+env:
+  # Set profiles.yml directory
+  DBT_PROFILES_DIR: ./ci
+
+  # Redshift Connection
+  # REDSHIFT_TEST_HOST: ${{ secrets.REDSHIFT_TEST_HOST }}
+  # REDSHIFT_TEST_USER: ${{ secrets.REDSHIFT_TEST_USER }}
+  # REDSHIFT_TEST_PASS: ${{ secrets.REDSHIFT_TEST_PASS }}
+  # REDSHIFT_TEST_DBNAME: ${{ secrets.REDSHIFT_TEST_DBNAME }}
+  # REDSHIFT_TEST_PORT: ${{ secrets.REDSHIFT_TEST_PORT }}
+
+  # BigQuery Connection
+  BIGQUERY_SERVICE_KEYFILE: ${{ secrets.BIGQUERY_SERVICE_KEYFILE }}
+  BIGQUERY_SERVICE_KEY_PATH: ./dbt-service-account.json
+  BIGQUERY_TEST_DATABASE: ${{ secrets.BIGQUERY_TEST_DATABASE }}
+  BIGQUERY_LOCATION: ${{ secrets.BIGQUERY_LOCATION }}
+
+  # Snowflake Connection
+  SNOWFLAKE_TEST_ACCOUNT: ${{ secrets.SNOWFLAKE_TEST_ACCOUNT }}
+  SNOWFLAKE_TEST_USER: ${{ secrets.SNOWFLAKE_TEST_USER }}
+  SNOWFLAKE_TEST_PASSWORD: ${{ secrets.SNOWFLAKE_TEST_PASSWORD }}
+  SNOWFLAKE_TEST_ROLE: ${{ secrets.SNOWFLAKE_TEST_ROLE }}
+  SNOWFLAKE_TEST_DATABASE: ${{ secrets.SNOWFLAKE_TEST_DATABASE }}
+  SNOWFLAKE_TEST_WAREHOUSE: ${{ secrets.SNOWFLAKE_TEST_WAREHOUSE }}
+
+  # # Postgres Connection
+  # POSTGRES_TEST_HOST: ${{ secrets.POSTGRES_TEST_HOST }}
+  # POSTGRES_TEST_USER: ${{ secrets.POSTGRES_TEST_USER }}
+  # POSTGRES_TEST_PASS: ${{ secrets.POSTGRES_TEST_PASS }}
+  # POSTGRES_TEST_PORT: ${{ secrets.POSTGRES_TEST_PORT }}
+  # POSTGRES_TEST_DBNAME: ${{ secrets.POSTGRES_TEST_DBNAME }}
+
+  # Databricks Connection
+  DATABRICKS_TEST_HOST: ${{ secrets.DATABRICKS_TEST_HOST }}
+  DATABRICKS_TEST_HTTP_PATH: ${{ secrets.DATABRICKS_TEST_HTTP_PATH }}
+  DATABRICKS_TEST_TOKEN: ${{ secrets.DATABRICKS_TEST_TOKEN }}
+  DATABRICKS_TEST_ENDPOINT: ${{ secrets.DATABRICKS_TEST_ENDPOINT }}
+
+jobs:
+  pr_tests:
+    name: pr_tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        # Run tests from integration_tests sub dir
+        working-directory: ./integration_tests
+    strategy:
+      matrix:
+        dbt_version: ["1.*"]
+        warehouse: ["bigquery", "snowflake", "databricks"]
+
+    steps:
+      - name: Check out
+        uses: actions/checkout@v3
+
+      # Remove '*' and replace '.' with '_' in DBT_VERSION & set as SCHEMA_SUFFIX.
+      # SCHEMA_SUFFIX allows us to run multiple versions of dbt in parallel without overwriting the output tables
+      - name: Set SCHEMA_SUFFIX env
+        run: echo "SCHEMA_SUFFIX=$(echo ${DBT_VERSION%.*} | tr . _)" >> $GITHUB_ENV
+        env:
+          DBT_VERSION: ${{ matrix.dbt_version }}
+
+      - name: Set DEFAULT_TARGET env
+        run: |
+         echo "DEFAULT_TARGET=${{ matrix.warehouse }}" >> $GITHUB_ENV
+
+      - name: Write BigQuery creds to json file
+        run: |
+         echo "$BIGQUERY_SERVICE_KEYFILE" > ./dbt-service-account.json
+
+      - name: Python setup
+        uses: actions/setup-python@v4
+        with:
+         python-version: "3.8.x"
+
+      - name: Pip cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ matrix.dbt_version }}-${{ matrix.warehouse }}
+          restore-keys: |
+            ${{ runner.os }}-pip-${{ matrix.dbt_version }}-${{ matrix.warehouse }}
+
+      # Install latest patch version. Upgrade if cache contains old patch version.
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip wheel setuptools
+          pip install -Iv dbt-${{ matrix.warehouse }}==${{ matrix.dbt_version }} --upgrade
+          dbt deps
+        if: ${{matrix.warehouse != 'spark'}}
+
+      - name: Install spark dependencies
+        run: |
+          pip install --upgrade pip wheel setuptools
+          pip install -Iv "dbt-${{ matrix.warehouse }}[ODBC]"==${{ matrix.dbt_version }} --upgrade
+          dbt deps
+        if: ${{matrix.warehouse == 'spark'}}
+
+      - name: Run tests
+        run: ./.scripts/integration_test.sh -d ${{ matrix.warehouse }}

--- a/integration_tests/.gitignore
+++ b/integration_tests/.gitignore
@@ -1,0 +1,4 @@
+
+target/
+dbt_modules/
+logs/

--- a/integration_tests/.scripts/integration_test.sh
+++ b/integration_tests/.scripts/integration_test.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Expected input:
+# -d (database) target database for dbt
+
+while getopts 'd:' opt
+do
+  case $opt in
+    d) DATABASE=$OPTARG
+  esac
+done
+
+declare -a SUPPORTED_DATABASES=("bigquery" "databricks" "snowflake")
+
+# set to lower case
+DATABASE="$(echo $DATABASE | tr '[:upper:]' '[:lower:]')"
+
+if [[ $DATABASE == "all" ]]; then
+  DATABASES=( "${SUPPORTED_DATABASES[@]}" )
+else
+  DATABASES=$DATABASE
+fi
+
+for db in ${DATABASES[@]}; do
+
+  echo "Snowplow normalize integration tests: snakeify case"
+
+  eval "dbt run-operation test_snakeify_case --target $db" || exit 1;
+
+  echo "Snowplow normalize integration tests: normalize events"
+
+  eval "dbt run-operation test_normalize_events --target $db" || exit 1;
+
+  echo "Snowplow normalize integration tests: users table"
+
+  eval "dbt run-operation test_users_table --target $db" || exit 1;
+
+  echo "Snowplow normalize integration tests: All tests passed"
+
+done

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -1,0 +1,13 @@
+# snowplow-normalize-integration-tests
+
+Integration test suite for the snowplow-normalize dbt package.
+
+The `./scripts` directory contains one scripts:
+
+- `integration_tests.sh`: This tests the macros of the snowplow-normalize package. It physically checks the output of the macros to ensure it matches what we expect, but doesn't actually process any data directly.
+
+Run the scripts using:
+
+```bash
+bash integration_tests.sh -d {warehouse}
+```

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -4,7 +4,7 @@ Integration test suite for the snowplow-normalize dbt package.
 
 The `./scripts` directory contains one scripts:
 
-- `integration_tests.sh`: This tests the macros of the snowplow-normalize package. It physically checks the output of the macros to ensure it matches what we expect, but doesn't actually process any data directly.
+- `integration_tests.sh`: This tests the macros of the snowplow-normalize package. It checks the compiled output of the macros to ensure it matches what we expect, but doesn't actually process any data directly.
 
 Run the scripts using:
 

--- a/integration_tests/ci/profiles.yml
+++ b/integration_tests/ci/profiles.yml
@@ -1,0 +1,68 @@
+
+# HEY! This file is used in the Snowplow dbt normalize integration tests.
+# You should __NEVER__ check credentials into version control. Thanks for reading :)
+
+config:
+    send_anonymous_usage_stats: False
+    use_colors: True
+
+integration_tests:
+  target: "{{ env_var('DEFAULT_TARGET') }}"
+  outputs:
+    # postgres:
+    #   type: postgres
+    #   host: "{{ env_var('POSTGRES_TEST_HOST') }}"
+    #   user: "{{ env_var('POSTGRES_TEST_USER') }}"
+    #   pass: "{{ env_var('POSTGRES_TEST_PASS') }}"
+    #   port: "{{ env_var('POSTGRES_TEST_PORT') | as_number }}"
+    #   dbname: "{{ env_var('POSTGRES_TEST_DBNAME') }}"
+    #   schema: "github_snwplow_web_dbt_{{ env_var('SCHEMA_SUFFIX') }}"
+    #   threads: 4
+
+    # redshift:
+    #   type: redshift
+    #   host: "{{ env_var('REDSHIFT_TEST_HOST') }}"
+    #   user: "{{ env_var('REDSHIFT_TEST_USER') }}"
+    #   pass: "{{ env_var('REDSHIFT_TEST_PASS') }}"
+    #   dbname: "{{ env_var('REDSHIFT_TEST_DBNAME') }}"
+    #   port: "{{ env_var('REDSHIFT_TEST_PORT') | as_number }}"
+    #   schema: "github_snwplow_web_dbt_{{ env_var('SCHEMA_SUFFIX') }}"
+    #   threads: 4
+
+    bigquery:
+      type: bigquery
+      method: service-account
+      keyfile: "{{ env_var('BIGQUERY_SERVICE_KEY_PATH') }}"
+      project: "{{ env_var('BIGQUERY_TEST_DATABASE') }}"
+      location: "{{ env_var('BIGQUERY_LOCATION') }}"
+      schema: "github_snwplow_web_dbt_{{ env_var('SCHEMA_SUFFIX') }}"
+      threads: 4
+
+    snowflake:
+      type: snowflake
+      account: "{{ env_var('SNOWFLAKE_TEST_ACCOUNT') }}"
+      user: "{{ env_var('SNOWFLAKE_TEST_USER') }}"
+      password: "{{ env_var('SNOWFLAKE_TEST_PASSWORD') }}"
+      role: "{{ env_var('SNOWFLAKE_TEST_ROLE') }}"
+      database: "{{ env_var('SNOWFLAKE_TEST_DATABASE') }}"
+      warehouse: "{{ env_var('SNOWFLAKE_TEST_WAREHOUSE') }}"
+      schema: "github_snwplow_web_dbt_{{ env_var('SCHEMA_SUFFIX') }}"
+      threads: 4
+
+    databricks:
+      type: databricks
+      schema: "github_snwplow_web_dbt_{{ env_var('SCHEMA_SUFFIX') }}"
+      host: "{{ env_var('DATABRICKS_TEST_HOST') }}"
+      http_path: "{{ env_var('DATABRICKS_TEST_HTTP_PATH') }}"
+      token: "{{ env_var('DATABRICKS_TEST_TOKEN') }}"
+      threads: 4
+
+    # spark:
+    #   type: spark
+    #   method: odbc
+    #   driver: "{{ env_var('DATABRICKS_TEST_HTTP_PATH') }}"
+    #   schema: "github_snwplow_web_dbt_{{ env_var('SCHEMA_SUFFIX') }}"
+    #   host: "{{ env_var('DATABRICKS_TEST_HOST') }}"
+    #   token: "{{ env_var('DATABRICKS_TEST_TOKEN') }}"
+    #   endpoint: "{{ env_var('DATABRICKS_TEST_ENDPOINT') }}"
+    #   threads: 4

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,0 +1,21 @@
+name: 'snowplow_normalize_integration_tests'
+version: '0.1.0'
+config-version: 2
+
+profile: 'integration_tests'
+
+model-paths: ["models"]
+analysis-paths: ["analysis"]
+test-paths: ["tests"]
+seed-paths: ["data"]
+macro-paths: ["macros"]
+
+target-path: "target"
+clean-targets:
+    - "target"
+    - "dbt_modules"
+    - "dbt_packages"
+
+quoting:
+  identifier: false
+  schema: false

--- a/integration_tests/macros/test_normalize_events.sql
+++ b/integration_tests/macros/test_normalize_events.sql
@@ -1,0 +1,128 @@
+{# This tests the output of a dummy set of inputs to the normalize events macro to ensure that it returns what we expect to come out does.
+This doesn't run on any actual data, we are just comparing the sql that is generated - removing whitespace to allow for changes to that.
+Note that we have to pass the test = true argument for this to work without having to create all the manifest and event limits table.
+
+It runs 6 tests:
+1) Just flat columns, no sde or context
+2) (1) plus an SDE
+3) (2) + 1 context
+4) (2) + 2 contexts
+5) (4) + aliases
+6) (1) + 2 contexts
+
+#}
+
+{% macro test_normalize_events() %}
+
+    {{ return(adapter.dispatch('test_normalize_events', 'snowplow_normalize_integration_tests')()) }}
+
+{% endmacro %}
+
+{% macro bigquery__test_normalize_events() %}
+
+    {% set expected_dict = {
+        "flat_cols_only" : "select event_id , collector_tstamp -- Flat columns from event table , app_id -- self describing events column from event table -- context column(s) from the event table from `"~target.project~"`."~target.dataset~"_scratch.snowplow_normalize_base_events_this_run where event_name = 'event_name'",
+        "sde_plus_cols" : "select event_id , collector_tstamp -- Flat columns from event table , app_id -- self describing events column from event table , UNSTRUCT_EVENT_TEST_1_0_1.test_id as test_id , UNSTRUCT_EVENT_TEST_1_0_1.test_class as test_class -- context column(s) from the event table from `"~target.project~"`."~target.dataset~"_scratch.snowplow_normalize_base_events_this_run where event_name = 'event_name'",
+        "sde_plus_1_context" : "select event_id , collector_tstamp -- Flat columns from event table , app_id -- self describing events column from event table , UNSTRUCT_EVENT_TEST_1_0_1.test_id as test_id , UNSTRUCT_EVENT_TEST_1_0_1.test_class as test_class -- context column(s) from the event table , CONTEXTS_TEST_1_0_0[SAFE_OFFSET(0)].context_test_id as context_test_id, CONTEXTS_TEST_1_0_0[SAFE_OFFSET(0)].context_test_class as context_test_class from `"~target.project~"`."~target.dataset~"_scratch.snowplow_normalize_base_events_this_run where event_name = 'event_name'",
+        "sde_plus_2_context" : "select event_id , collector_tstamp -- Flat columns from event table , app_id -- self describing events column from event table , UNSTRUCT_EVENT_TEST_1_0_1.test_id as test_id , UNSTRUCT_EVENT_TEST_1_0_1.test_class as test_class -- context column(s) from the event table , CONTEXTS_TEST_1_0_0[SAFE_OFFSET(0)].context_test_id as context_test_id, CONTEXTS_TEST_1_0_0[SAFE_OFFSET(0)].context_test_class as context_test_class, CONTEXT_TEST2_1_0_5[SAFE_OFFSET(0)].context_test_id2 as context_test_id2, CONTEXT_TEST2_1_0_5[SAFE_OFFSET(0)].context_test_class2 as context_test_class2 from `"~target.project~"`."~target.dataset~"_scratch.snowplow_normalize_base_events_this_run where event_name = 'event_name'",
+        "sde_plus_2_context_w_alias" : "select event_id , collector_tstamp -- Flat columns from event table , app_id -- self describing events column from event table , UNSTRUCT_EVENT_TEST_1_0_1.test_id as test_id , UNSTRUCT_EVENT_TEST_1_0_1.test_class as test_class -- context column(s) from the event table , CONTEXTS_TEST_1_0_0[SAFE_OFFSET(0)].context_test_id as test1_context_test_id , CONTEXTS_TEST_1_0_0[SAFE_OFFSET(0)].context_test_class as test1_context_test_class , CONTEXT_TEST2_1_0_5[SAFE_OFFSET(0)].context_test_id2 as test2_context_test_id2 , CONTEXT_TEST2_1_0_5[SAFE_OFFSET(0)].context_test_class2 as test2_context_test_class2 from `"~target.project~"`."~target.dataset~"_scratch.snowplow_normalize_base_events_this_run where event_name = 'event_name'",
+        "context_only" : "select event_id , collector_tstamp -- Flat columns from event table , app_id -- self describing events column from event table -- context column(s) from the event table , CONTEXTS_TEST_1_0_0[SAFE_OFFSET(0)].context_test_id as context_test_id, CONTEXTS_TEST_1_0_0[SAFE_OFFSET(0)].context_test_class as context_test_class, CONTEXT_TEST2_1_0_5[SAFE_OFFSET(0)].context_test_id2 as context_test_id2, CONTEXT_TEST2_1_0_5[SAFE_OFFSET(0)].context_test_class2 as context_test_class2 from `"~target.project~"`."~target.dataset~"_scratch.snowplow_normalize_base_events_this_run where event_name = 'event_name'"
+    } %}
+
+
+
+    {% set results_dict ={
+        "flat_cols_only" : snowplow_normalize.normalize_events('event_name', ['app_id'], '', [], [], [], [], [], [], true).split()|join(' '),
+        "sde_plus_cols" : snowplow_normalize.normalize_events('event_name', ['app_id'], 'UNSTRUCT_EVENT_TEST_1_0_1', ['testId', 'testClass'], ['string', 'boolean'], [], [], [], [], true).split()|join(' '),
+        "sde_plus_1_context" : snowplow_normalize.normalize_events('event_name', ['app_id'], 'UNSTRUCT_EVENT_TEST_1_0_1', ['testId', 'testClass'], ['string', 'boolean'], ['CONTEXTS_TEST_1_0_0'], [['contextTestId', 'contextTestClass']], [['string', 'integer']], [], true).split()|join(' '),
+        "sde_plus_2_context" : snowplow_normalize.normalize_events('event_name', ['app_id'], 'UNSTRUCT_EVENT_TEST_1_0_1', ['testId', 'testClass'], ['string', 'boolean'], ['CONTEXTS_TEST_1_0_0', 'CONTEXT_TEST2_1_0_5'], [['contextTestId', 'contextTestClass'], ['contextTestId2', 'contextTestClass2']], [['boolean', 'string'], ['interger', 'string']], [], true).split()|join(' '),
+        "sde_plus_2_context_w_alias" : snowplow_normalize.normalize_events('event_name', ['app_id'], 'UNSTRUCT_EVENT_TEST_1_0_1', ['testId', 'testClass'], ['string', 'boolean'], ['CONTEXTS_TEST_1_0_0', 'CONTEXT_TEST2_1_0_5'], [['contextTestId', 'contextTestClass'],['contextTestId2', 'contextTestClass2'] ], [['boolean', 'string'], ['interger', 'string']], ['test1', 'test2'], true).split()|join(' '),
+        "context_only" : snowplow_normalize.normalize_events('event_name', ['app_id'], '', [], [], ['CONTEXTS_TEST_1_0_0', 'CONTEXT_TEST2_1_0_5'], [['contextTestId', 'contextTestClass'],['contextTestId2', 'contextTestClass2'] ], [['boolean', 'string'], ['interger', 'string']], [], true).split()|join(' ')
+        }
+    %}
+
+
+    {# {{ print(results_dict['flat_cols_only'])}} #}
+    {# {{ print(results_dict['sde_plus_cols'])}} #}
+    {# {{ print(results_dict['sde_plus_1_context'])}} #}
+    {# {{ print(results_dict['sde_plus_2_context'])}} #}
+    {# {{ print(results_dict['sde_plus_2_context_w_alias'])}} #}
+    {# {{ print(results_dict['context_only'])}} #}
+
+
+    {{ dbt_unittest.assert_equals(expected_dict, results_dict) }}
+
+
+{% endmacro %}
+
+
+{% macro databricks__test_normalize_events() %}
+
+    {% set expected_dict = {
+        "flat_cols_only" : "select event_id , collector_tstamp , DATE(collector_tstamp) as collector_tstamp_date -- Flat columns from event table , app_id -- self describing events column from event table -- context column(s) from the event table from "~target.schema~"_scratch.snowplow_normalize_base_events_this_run where event_name = 'event_name'",
+        "sde_plus_cols" : "select event_id , collector_tstamp , DATE(collector_tstamp) as collector_tstamp_date -- Flat columns from event table , app_id -- self describing events column from event table , UNSTRUCT_EVENT_TEST_1.test_id as test_id , UNSTRUCT_EVENT_TEST_1.test_class as test_class -- context column(s) from the event table from "~target.schema~"_scratch.snowplow_normalize_base_events_this_run where event_name = 'event_name'",
+        "sde_plus_1_context" : "select event_id , collector_tstamp , DATE(collector_tstamp) as collector_tstamp_date -- Flat columns from event table , app_id -- self describing events column from event table , UNSTRUCT_EVENT_TEST_1.test_id as test_id , UNSTRUCT_EVENT_TEST_1.test_class as test_class -- context column(s) from the event table , CONTEXTS_TEST_1[0].context_test_id as context_test_id, CONTEXTS_TEST_1[0].context_test_class as context_test_class from "~target.schema~"_scratch.snowplow_normalize_base_events_this_run where event_name = 'event_name'",
+        "sde_plus_2_context" : "select event_id , collector_tstamp , DATE(collector_tstamp) as collector_tstamp_date -- Flat columns from event table , app_id -- self describing events column from event table , UNSTRUCT_EVENT_TEST_1.test_id as test_id , UNSTRUCT_EVENT_TEST_1.test_class as test_class -- context column(s) from the event table , CONTEXTS_TEST_1[0].context_test_id as context_test_id, CONTEXTS_TEST_1[0].context_test_class as context_test_class, CONTEXT_TEST2_1[0].context_test_id2 as context_test_id2, CONTEXT_TEST2_1[0].context_test_class2 as context_test_class2 from "~target.schema~"_scratch.snowplow_normalize_base_events_this_run where event_name = 'event_name'",
+        "sde_plus_2_context_w_alias" : "select event_id , collector_tstamp , DATE(collector_tstamp) as collector_tstamp_date -- Flat columns from event table , app_id -- self describing events column from event table , UNSTRUCT_EVENT_TEST_1.test_id as test_id , UNSTRUCT_EVENT_TEST_1.test_class as test_class -- context column(s) from the event table , CONTEXTS_TEST_1[0].context_test_id as test1_context_test_id , CONTEXTS_TEST_1[0].context_test_class as test1_context_test_class , CONTEXT_TEST2_1[0].context_test_id2 as test2_context_test_id2 , CONTEXT_TEST2_1[0].context_test_class2 as test2_context_test_class2 from "~target.schema~"_scratch.snowplow_normalize_base_events_this_run where event_name = 'event_name'",
+        "context_only" : "select event_id , collector_tstamp , DATE(collector_tstamp) as collector_tstamp_date -- Flat columns from event table , app_id -- self describing events column from event table -- context column(s) from the event table , CONTEXTS_TEST_1[0].context_test_id as context_test_id, CONTEXTS_TEST_1[0].context_test_class as context_test_class, CONTEXT_TEST2_1[0].context_test_id2 as context_test_id2, CONTEXT_TEST2_1[0].context_test_class2 as context_test_class2 from "~target.schema~"_scratch.snowplow_normalize_base_events_this_run where event_name = 'event_name'"
+    } %}
+
+    {% set results_dict ={
+        "flat_cols_only" : snowplow_normalize.normalize_events('event_name', ['app_id'], '', [], [], [], [], [], [], true).split()|join(' '),
+        "sde_plus_cols" : snowplow_normalize.normalize_events('event_name', ['app_id'], 'UNSTRUCT_EVENT_TEST_1_0_1', ['testId', 'testClass'], ['string', 'boolean'], [], [], [], [], true).split()|join(' '),
+        "sde_plus_1_context" : snowplow_normalize.normalize_events('event_name', ['app_id'], 'UNSTRUCT_EVENT_TEST_1_0_1', ['testId', 'testClass'], ['string', 'boolean'], ['CONTEXTS_TEST_1_0_0'], [['contextTestId', 'contextTestClass']], [['string', 'integer']], [], true).split()|join(' '),
+        "sde_plus_2_context" : snowplow_normalize.normalize_events('event_name', ['app_id'], 'UNSTRUCT_EVENT_TEST_1_0_1', ['testId', 'testClass'], ['string', 'boolean'], ['CONTEXTS_TEST_1_0_0', 'CONTEXT_TEST2_1_0_5'], [['contextTestId', 'contextTestClass'], ['contextTestId2', 'contextTestClass2']], [['boolean', 'string'], ['interger', 'string']], [], true).split()|join(' '),
+        "sde_plus_2_context_w_alias" : snowplow_normalize.normalize_events('event_name', ['app_id'], 'UNSTRUCT_EVENT_TEST_1_0_1', ['testId', 'testClass'], ['string', 'boolean'], ['CONTEXTS_TEST_1_0_0', 'CONTEXT_TEST2_1_0_5'], [['contextTestId', 'contextTestClass'],['contextTestId2', 'contextTestClass2'] ], [['boolean', 'string'], ['interger', 'string']], ['test1', 'test2'], true).split()|join(' '),
+        "context_only" : snowplow_normalize.normalize_events('event_name', ['app_id'], '', [], [], ['CONTEXTS_TEST_1_0_0', 'CONTEXT_TEST2_1_0_5'], [['contextTestId', 'contextTestClass'],['contextTestId2', 'contextTestClass2'] ], [['boolean', 'string'], ['interger', 'string']], [], true).split()|join(' ')
+        }
+    %}
+
+
+    {# {{ print(results_dict['flat_cols_only'])}} #}
+    {# {{ print(results_dict['sde_plus_cols'])}} #}
+    {# {{ print(results_dict['sde_plus_1_context'])}} #}
+    {# {{ print(results_dict['sde_plus_2_context'])}} #}
+    {# {{ print(results_dict['sde_plus_2_context_w_alias'])}} #}
+    {# {{ print(results_dict['context_only'])}} #}
+
+
+    {{ dbt_unittest.assert_equals(expected_dict, results_dict) }}
+
+
+{% endmacro %}
+
+
+{% macro snowflake__test_normalize_events() %}
+
+    {% set expected_dict = {
+        "flat_cols_only" : "select event_id , collector_tstamp -- Flat columns from event table , app_id -- self describing events column from event table -- context column(s) from the event table from "~target.database~"."~target.schema~"_scratch.snowplow_normalize_base_events_this_run where event_name = 'event_name'",
+        "sde_plus_cols" : "select event_id , collector_tstamp -- Flat columns from event table , app_id -- self describing events column from event table , UNSTRUCT_EVENT_TEST_1:testId::string as test_id , UNSTRUCT_EVENT_TEST_1:testClass::boolean as test_class -- context column(s) from the event table from "~target.database~"."~target.schema~"_scratch.snowplow_normalize_base_events_this_run where event_name = 'event_name'",
+        "sde_plus_1_context" : "select event_id , collector_tstamp -- Flat columns from event table , app_id -- self describing events column from event table , UNSTRUCT_EVENT_TEST_1:testId::string as test_id , UNSTRUCT_EVENT_TEST_1:testClass::boolean as test_class -- context column(s) from the event table , CONTEXTS_TEST_1[0]:contextTestId::string as context_test_id, CONTEXTS_TEST_1[0]:contextTestClass::integer as context_test_class from "~target.database~"."~target.schema~"_scratch.snowplow_normalize_base_events_this_run where event_name = 'event_name'",
+        "sde_plus_2_context" : "select event_id , collector_tstamp -- Flat columns from event table , app_id -- self describing events column from event table , UNSTRUCT_EVENT_TEST_1:testId::string as test_id , UNSTRUCT_EVENT_TEST_1:testClass::boolean as test_class -- context column(s) from the event table , CONTEXTS_TEST_1[0]:contextTestId::boolean as context_test_id, CONTEXTS_TEST_1[0]:contextTestClass::string as context_test_class, CONTEXT_TEST2_1[0]:contextTestId2::interger as context_test_id2, CONTEXT_TEST2_1[0]:contextTestClass2::string as context_test_class2 from "~target.database~"."~target.schema~"_scratch.snowplow_normalize_base_events_this_run where event_name = 'event_name'",
+        "sde_plus_2_context_w_alias" : "select event_id , collector_tstamp -- Flat columns from event table , app_id -- self describing events column from event table , UNSTRUCT_EVENT_TEST_1:testId::string as test_id , UNSTRUCT_EVENT_TEST_1:testClass::boolean as test_class -- context column(s) from the event table , CONTEXTS_TEST_1[0]:contextTestId::boolean as test1_context_test_id , CONTEXTS_TEST_1[0]:contextTestClass::string as test1_context_test_class , CONTEXT_TEST2_1[0]:contextTestId2::interger as test2_context_test_id2 , CONTEXT_TEST2_1[0]:contextTestClass2::string as test2_context_test_class2 from "~target.database~"."~target.schema~"_scratch.snowplow_normalize_base_events_this_run where event_name = 'event_name'",
+        "context_only" : "select event_id , collector_tstamp -- Flat columns from event table , app_id -- self describing events column from event table -- context column(s) from the event table , CONTEXTS_TEST_1[0]:contextTestId::boolean as context_test_id, CONTEXTS_TEST_1[0]:contextTestClass::string as context_test_class, CONTEXT_TEST2_1[0]:contextTestId2::interger as context_test_id2, CONTEXT_TEST2_1[0]:contextTestClass2::string as context_test_class2 from "~target.database~"."~target.schema~"_scratch.snowplow_normalize_base_events_this_run where event_name = 'event_name'"
+    } %}
+
+   {% set results_dict ={
+        "flat_cols_only" : snowplow_normalize.normalize_events('event_name', ['app_id'], '', [], [], [], [], [], [], true).split()|join(' '),
+        "sde_plus_cols" : snowplow_normalize.normalize_events('event_name', ['app_id'], 'UNSTRUCT_EVENT_TEST_1_0_1', ['testId', 'testClass'], ['string', 'boolean'], [], [], [], [], true).split()|join(' '),
+        "sde_plus_1_context" : snowplow_normalize.normalize_events('event_name', ['app_id'], 'UNSTRUCT_EVENT_TEST_1_0_1', ['testId', 'testClass'], ['string', 'boolean'], ['CONTEXTS_TEST_1_0_0'], [['contextTestId', 'contextTestClass']], [['string', 'integer']], [], true).split()|join(' '),
+        "sde_plus_2_context" : snowplow_normalize.normalize_events('event_name', ['app_id'], 'UNSTRUCT_EVENT_TEST_1_0_1', ['testId', 'testClass'], ['string', 'boolean'], ['CONTEXTS_TEST_1_0_0', 'CONTEXT_TEST2_1_0_5'], [['contextTestId', 'contextTestClass'], ['contextTestId2', 'contextTestClass2']], [['boolean', 'string'], ['interger', 'string']], [], true).split()|join(' '),
+        "sde_plus_2_context_w_alias" : snowplow_normalize.normalize_events('event_name', ['app_id'], 'UNSTRUCT_EVENT_TEST_1_0_1', ['testId', 'testClass'], ['string', 'boolean'], ['CONTEXTS_TEST_1_0_0', 'CONTEXT_TEST2_1_0_5'], [['contextTestId', 'contextTestClass'],['contextTestId2', 'contextTestClass2'] ], [['boolean', 'string'], ['interger', 'string']], ['test1', 'test2'], true).split()|join(' '),
+        "context_only" : snowplow_normalize.normalize_events('event_name', ['app_id'], '', [], [], ['CONTEXTS_TEST_1_0_0', 'CONTEXT_TEST2_1_0_5'], [['contextTestId', 'contextTestClass'],['contextTestId2', 'contextTestClass2'] ], [['boolean', 'string'], ['interger', 'string']], [], true).split()|join(' ')
+        }
+    %}
+
+
+    {# {{ print(results_dict['flat_cols_only'])}}
+    {{ print(results_dict['sde_plus_cols'])}}
+    {{ print(results_dict['sde_plus_1_context'])}}
+    {{ print(results_dict['sde_plus_2_context'])}}
+    {{ print(results_dict['sde_plus_2_context_w_alias'])}}
+    {{ print(results_dict['context_only'])}} #}
+
+
+    {{ dbt_unittest.assert_equals(expected_dict, results_dict) }}
+
+
+{% endmacro %}

--- a/integration_tests/macros/test_snakeify_case.sql
+++ b/integration_tests/macros/test_snakeify_case.sql
@@ -9,7 +9,7 @@ It runs 9 tests:
 5) camel case with multiple workds
 6) camel case ending with a series of capitals
 7) camel case with a series of capitals in the middle
-8) camel case with hypthons
+8) camel case with hyphens
 9) camel case with numbers
 
 
@@ -31,7 +31,7 @@ It runs 9 tests:
         "camel_multi_word" : "hello_world_earth",
         "camel_end_with_caps" :"hello_world_earth",
         "camel_middle_caps" : "hello_world_earth",
-        "camel_hypthons" : "hello_world_earth",
+        "camel_hyphens" : "hello_world_earth",
         "camel_numbers" : "hello_world23_earth"
     } %}
 
@@ -44,7 +44,7 @@ It runs 9 tests:
         "camel_end_with_caps" : snowplow_normalize.snakeify_case('helloWorldEARTH'),
         "camel_middle_caps" : snowplow_normalize.snakeify_case('helloWORLDEarth'),
         "camel_middle_caps" : snowplow_normalize.snakeify_case('helloWORLDEarth'),
-        "camel_hypthons" : snowplow_normalize.snakeify_case('helloWorld-Earth'),
+        "camel_hyphens" : snowplow_normalize.snakeify_case('helloWorld-Earth'),
         "camel_numbers" : snowplow_normalize.snakeify_case('helloWorld23Earth')
         }
     %}

--- a/integration_tests/macros/test_snakeify_case.sql
+++ b/integration_tests/macros/test_snakeify_case.sql
@@ -1,0 +1,56 @@
+{# This tests the output of a dummy set of inputs to the snakeify case macro to ensure that it returns what we expect to come out does.
+This doesn't run on any actual data, we are just comparing the text that is generated.
+
+It runs 9 tests:
+1) a single world, no change
+2) already snake case, no change
+3) pascal case
+4) camel case, basic
+5) camel case with multiple workds
+6) camel case ending with a series of capitals
+7) camel case with a series of capitals in the middle
+8) camel case with hypthons
+9) camel case with numbers
+
+
+#}
+
+{% macro test_snakeify_case() %}
+
+    {{ return(adapter.dispatch('test_snakeify_case', 'snowplow_normalize_integration_tests')()) }}
+
+{% endmacro %}
+
+{% macro default__test_snakeify_case() %}
+
+    {% set expected_dict = {
+        "single_word" : "hello",
+        "already_snake" : "hello_world",
+        "pascal_case" : "hello_world",
+        "camel_basic" : "hello_world",
+        "camel_multi_word" : "hello_world_earth",
+        "camel_end_with_caps" :"hello_world_earth",
+        "camel_middle_caps" : "hello_world_earth",
+        "camel_hypthons" : "hello_world_earth",
+        "camel_numbers" : "hello_world23_earth"
+    } %}
+
+    {% set results_dict ={
+        "single_word" : snowplow_normalize.snakeify_case('hello'),
+        "already_snake" : snowplow_normalize.snakeify_case('hello_world'),
+        "pascal_case" : snowplow_normalize.snakeify_case('HelloWorld'),
+        "camel_basic" : snowplow_normalize.snakeify_case('helloWorld'),
+        "camel_multi_word" : snowplow_normalize.snakeify_case('helloWorldEarth'),
+        "camel_end_with_caps" : snowplow_normalize.snakeify_case('helloWorldEARTH'),
+        "camel_middle_caps" : snowplow_normalize.snakeify_case('helloWORLDEarth'),
+        "camel_middle_caps" : snowplow_normalize.snakeify_case('helloWORLDEarth'),
+        "camel_hypthons" : snowplow_normalize.snakeify_case('helloWorld-Earth'),
+        "camel_numbers" : snowplow_normalize.snakeify_case('helloWorld23Earth')
+        }
+    %}
+
+
+    {{ dbt_unittest.assert_equals(expected_dict, results_dict) }}
+
+
+{% endmacro %}

--- a/integration_tests/macros/test_users_table.sql
+++ b/integration_tests/macros/test_users_table.sql
@@ -1,0 +1,92 @@
+{# This tests the output of a dummy set of inputs to the user table macro to ensure that it returns what we expect to come out does.
+This doesn't run on any actual data, we are just comparing the sql that is generated - removing whitespace to allow for changes to that.
+Note that we have to pass the test = true argument for this to work without having to create all the manifest and event limits table.
+
+It runs 2 tests:
+1) A single context for the user
+2) 2 contexts for the user
+
+#}
+
+{% macro test_users_table() %}
+
+    {{ return(adapter.dispatch('test_users_table', 'snowplow_normalize_integration_tests')()) }}
+
+{% endmacro %}
+
+{% macro bigquery__test_users_table() %}
+
+    {% set expected_dict = {
+        "1_context" : "with users_ordering as ( select user_id , collector_tstamp as latest_collector_tstamp -- user column(s) from the event table , CONTEXTS_TEST_1_0_0[SAFE_OFFSET(0)].context_test_id as context_test_id , CONTEXTS_TEST_1_0_0[SAFE_OFFSET(0)].context_test_class as context_test_class , row_number() over (partition by user_id order by collector_tstamp desc) as rn from `"~target.project~"`."~target.dataset~"_scratch.snowplow_normalize_base_events_this_run where user_id is not null ) select * except (rn) from users_ordering where rn = 1",
+        "2_context" : "with users_ordering as ( select user_id , collector_tstamp as latest_collector_tstamp -- user column(s) from the event table , CONTEXTS_TEST_1_0_0[SAFE_OFFSET(0)].context_test_id as context_test_id , CONTEXTS_TEST_1_0_0[SAFE_OFFSET(0)].context_test_class as context_test_class , CONTEXT_TEST2_1_0_5[SAFE_OFFSET(0)].context_test_id2 as context_test_id2 , CONTEXT_TEST2_1_0_5[SAFE_OFFSET(0)].context_test_class2 as context_test_class2 , row_number() over (partition by user_id order by collector_tstamp desc) as rn from `"~target.project~"`."~target.dataset~"_scratch.snowplow_normalize_base_events_this_run where user_id is not null ) select * except (rn) from users_ordering where rn = 1"
+    } %}
+
+
+
+    {% set results_dict ={
+        "1_context" : snowplow_normalize.users_table(['CONTEXTS_TEST_1_0_0'], [['contextTestId', 'contextTestClass']], [['string', 'integer']], true).split()|join(' '),
+        "2_context" : snowplow_normalize.users_table(['CONTEXTS_TEST_1_0_0', 'CONTEXT_TEST2_1_0_5'], [['contextTestId', 'contextTestClass'], ['contextTestId2', 'contextTestClass2']], [['boolean', 'string'], ['interger', 'string']], true).split()|join(' '),
+        }
+    %}
+
+
+    {# {{ print(results_dict['1_context'])}} #}
+    {# {{ print(results_dict['2_context'])}} #}
+
+
+    {{ dbt_unittest.assert_equals(expected_dict, results_dict) }}
+
+
+{% endmacro %}
+
+
+{% macro databricks__test_users_table() %}
+
+    {% set expected_dict = {
+        "1_context" : "with users_ordering as ( select user_id , collector_tstamp as latest_collector_tstamp , DATE(collector_tstamp) as latest_collector_tstamp_date -- user column(s) from the event table , CONTEXTS_TEST_1[0].context_test_id as context_test_id , CONTEXTS_TEST_1[0].context_test_class as context_test_class , row_number() over (partition by user_id order by collector_tstamp desc) as rn from "~target.schema~"_scratch.snowplow_normalize_base_events_this_run where user_id is not null ) select * except (rn) from users_ordering where rn = 1",
+        "2_context" : "with users_ordering as ( select user_id , collector_tstamp as latest_collector_tstamp , DATE(collector_tstamp) as latest_collector_tstamp_date -- user column(s) from the event table , CONTEXTS_TEST_1[0].context_test_id as context_test_id , CONTEXTS_TEST_1[0].context_test_class as context_test_class , CONTEXT_TEST2_1[0].context_test_id2 as context_test_id2 , CONTEXT_TEST2_1[0].context_test_class2 as context_test_class2 , row_number() over (partition by user_id order by collector_tstamp desc) as rn from "~target.schema~"_scratch.snowplow_normalize_base_events_this_run where user_id is not null ) select * except (rn) from users_ordering where rn = 1"
+    } %}
+
+
+
+    {% set results_dict ={
+        "1_context" : snowplow_normalize.users_table(['CONTEXTS_TEST_1_0_0'], [['contextTestId', 'contextTestClass']], [['string', 'integer']], true).split()|join(' '),
+        "2_context" : snowplow_normalize.users_table(['CONTEXTS_TEST_1_0_0', 'CONTEXT_TEST2_1_0_5'], [['contextTestId', 'contextTestClass'], ['contextTestId2', 'contextTestClass2']], [['boolean', 'string'], ['interger', 'string']], true).split()|join(' '),
+        }
+    %}
+
+
+    {# {{ print(results_dict['1_context'])}} #}
+    {# {{ print(results_dict['2_context'])}} #}
+
+
+    {{ dbt_unittest.assert_equals(expected_dict, results_dict) }}
+
+
+{% endmacro %}
+
+
+{% macro snowflake__test_users_table() %}
+
+   {% set expected_dict = {
+        "1_context" : "select user_id , collector_tstamp as latest_collector_tstamp -- user column(s) from the event table , CONTEXTS_TEST_1[0]:contextTestId::string as context_test_id , CONTEXTS_TEST_1[0]:contextTestClass::integer as context_test_class from "~target.database~"."~target.schema~"_scratch.snowplow_normalize_base_events_this_run where user_id is not null qualify row_number() over (partition by user_id order by collector_tstamp desc) = 1",
+        "2_context" : "select user_id , collector_tstamp as latest_collector_tstamp -- user column(s) from the event table , CONTEXTS_TEST_1[0]:contextTestId::boolean as context_test_id , CONTEXTS_TEST_1[0]:contextTestClass::string as context_test_class , CONTEXT_TEST2_1[0]:contextTestId2::interger as context_test_id2 , CONTEXT_TEST2_1[0]:contextTestClass2::string as context_test_class2 from "~target.database~"."~target.schema~"_scratch.snowplow_normalize_base_events_this_run where user_id is not null qualify row_number() over (partition by user_id order by collector_tstamp desc) = 1",
+    } %}
+
+
+
+    {% set results_dict ={
+        "1_context" : snowplow_normalize.users_table(['CONTEXTS_TEST_1_0_0'], [['contextTestId', 'contextTestClass']], [['string', 'integer']], true).split()|join(' '),
+        "2_context" : snowplow_normalize.users_table(['CONTEXTS_TEST_1_0_0', 'CONTEXT_TEST2_1_0_5'], [['contextTestId', 'contextTestClass'], ['contextTestId2', 'contextTestClass2']], [['boolean', 'string'], ['interger', 'string']], true).split()|join(' '),
+        }
+    %}
+
+
+    {# {{ print(results_dict['1_context'])}} #}
+    {# {{ print(results_dict['2_context'])}} #}
+
+
+    {{ dbt_unittest.assert_equals(expected_dict, results_dict) }}
+
+
+{% endmacro %}

--- a/integration_tests/packages.yml
+++ b/integration_tests/packages.yml
@@ -1,0 +1,5 @@
+
+packages:
+  - local: ../
+  - package: "yu-iskw/dbt_unittest"
+    version: 0.3.0

--- a/macros/normalize_events.sql
+++ b/macros/normalize_events.sql
@@ -1,8 +1,8 @@
-{% macro normalize_events(event_name, flat_cols = [], sde_col = '', sde_keys = [], sde_types = [], context_cols = [], context_keys = [], context_types = [], context_aliases = []) %}
-    {{ return(adapter.dispatch('normalize_events', 'snowplow_normalize')(event_name, flat_cols, sde_col, sde_keys, sde_types, context_cols, context_keys, context_types, context_aliases)) }}
+{% macro normalize_events(event_name, flat_cols = [], sde_col = '', sde_keys = [], sde_types = [], context_cols = [], context_keys = [], context_types = [], context_aliases = [], test = false) %}
+    {{ return(adapter.dispatch('normalize_events', 'snowplow_normalize')(event_name, flat_cols, sde_col, sde_keys, sde_types, context_cols, context_keys, context_types, context_aliases, test)) }}
 {% endmacro %}
 
-{% macro snowflake__normalize_events(event_name, flat_cols, sde_col, sde_keys, sde_types, context_cols, context_keys, context_types, context_aliases) %}
+{% macro snowflake__normalize_events(event_name, flat_cols, sde_col, sde_keys, sde_types, context_cols, context_keys, context_types, context_aliases, test) %}
 {# Remove down to major version for Snowflake columns, drop 2 last _X values #}
 {%- set sde_col = '_'.join(sde_col.split('_')[:-2]) -%}
 {%- set context_cols_clean = [] -%}
@@ -41,11 +41,13 @@ from
     {{ ref('snowplow_normalize_base_events_this_run') }}
 where
     event_name = '{{ event_name }}'
-    and {{ snowplow_utils.is_run_with_new_events("snowplow_normalize") }}
+    {% if not test %}
+        and {{ snowplow_utils.is_run_with_new_events("snowplow_normalize") }}
+    {%- endif -%}
 {% endmacro %}
 
 
-{% macro bigquery__normalize_events(event_name, flat_cols, sde_col, sde_keys, sde_types, context_cols, context_keys, context_types, context_aliases) %}
+{% macro bigquery__normalize_events(event_name, flat_cols, sde_col, sde_keys, sde_types, context_cols, context_keys, context_types, context_aliases, test) %}
 {# Replace keys with snake_case where needed #}
 {%- set sde_keys_clean = [] -%}
 {%- set context_keys_clean = [] -%}
@@ -91,10 +93,12 @@ from
     {{ ref('snowplow_normalize_base_events_this_run') }}
 where
     event_name = '{{ event_name }}'
-    and {{ snowplow_utils.is_run_with_new_events("snowplow_normalize") }}
+    {% if not test %}
+        and {{ snowplow_utils.is_run_with_new_events("snowplow_normalize") }}
+    {%- endif -%}
 {% endmacro %}
 
-{% macro databricks__normalize_events(event_name, flat_cols, sde_col, sde_keys, sde_types, context_cols, context_keys, context_types, context_aliases) %}
+{% macro databricks__normalize_events(event_name, flat_cols, sde_col, sde_keys, sde_types, context_cols, context_keys, context_types, context_aliases, test) %}
 {# Remove down to major version for Databricks columns, drop 2 last _X values #}
 {%- set sde_col = '_'.join(sde_col.split('_')[:-2]) -%}
 {%- set context_cols_clean = [] -%}
@@ -150,5 +154,7 @@ from
     {{ ref('snowplow_normalize_base_events_this_run') }}
 where
     event_name = '{{ event_name }}'
-    and {{ snowplow_utils.is_run_with_new_events("snowplow_normalize") }}
+    {% if not test %}
+        and {{ snowplow_utils.is_run_with_new_events("snowplow_normalize") }}
+    {%- endif -%}
 {% endmacro %}

--- a/macros/normalize_events.sql
+++ b/macros/normalize_events.sql
@@ -1,8 +1,8 @@
-{% macro normalize_events(event_name, flat_cols = [], sde_col = '', sde_keys = [], sde_types = [], context_cols = [], context_keys = [], context_types = [], context_aliases = [], test = false) %}
-    {{ return(adapter.dispatch('normalize_events', 'snowplow_normalize')(event_name, flat_cols, sde_col, sde_keys, sde_types, context_cols, context_keys, context_types, context_aliases, test)) }}
+{% macro normalize_events(event_name, flat_cols = [], sde_col = '', sde_keys = [], sde_types = [], context_cols = [], context_keys = [], context_types = [], context_aliases = [], remove_new_event_check = false) %}
+    {{ return(adapter.dispatch('normalize_events', 'snowplow_normalize')(event_name, flat_cols, sde_col, sde_keys, sde_types, context_cols, context_keys, context_types, context_aliases, remove_new_event_check)) }}
 {% endmacro %}
 
-{% macro snowflake__normalize_events(event_name, flat_cols, sde_col, sde_keys, sde_types, context_cols, context_keys, context_types, context_aliases, test) %}
+{% macro snowflake__normalize_events(event_name, flat_cols, sde_col, sde_keys, sde_types, context_cols, context_keys, context_types, context_aliases, remove_new_event_check) %}
 {# Remove down to major version for Snowflake columns, drop 2 last _X values #}
 {%- set sde_col = '_'.join(sde_col.split('_')[:-2]) -%}
 {%- set context_cols_clean = [] -%}
@@ -41,13 +41,13 @@ from
     {{ ref('snowplow_normalize_base_events_this_run') }}
 where
     event_name = '{{ event_name }}'
-    {% if not test %}
+    {% if not remove_new_event_check %}
         and {{ snowplow_utils.is_run_with_new_events("snowplow_normalize") }}
     {%- endif -%}
 {% endmacro %}
 
 
-{% macro bigquery__normalize_events(event_name, flat_cols, sde_col, sde_keys, sde_types, context_cols, context_keys, context_types, context_aliases, test) %}
+{% macro bigquery__normalize_events(event_name, flat_cols, sde_col, sde_keys, sde_types, context_cols, context_keys, context_types, context_aliases, remove_new_event_check) %}
 {# Replace keys with snake_case where needed #}
 {%- set sde_keys_clean = [] -%}
 {%- set context_keys_clean = [] -%}
@@ -93,12 +93,12 @@ from
     {{ ref('snowplow_normalize_base_events_this_run') }}
 where
     event_name = '{{ event_name }}'
-    {% if not test %}
+    {% if not remove_new_event_check %}
         and {{ snowplow_utils.is_run_with_new_events("snowplow_normalize") }}
     {%- endif -%}
 {% endmacro %}
 
-{% macro databricks__normalize_events(event_name, flat_cols, sde_col, sde_keys, sde_types, context_cols, context_keys, context_types, context_aliases, test) %}
+{% macro databricks__normalize_events(event_name, flat_cols, sde_col, sde_keys, sde_types, context_cols, context_keys, context_types, context_aliases, remove_new_event_check) %}
 {# Remove down to major version for Databricks columns, drop 2 last _X values #}
 {%- set sde_col = '_'.join(sde_col.split('_')[:-2]) -%}
 {%- set context_cols_clean = [] -%}
@@ -154,7 +154,7 @@ from
     {{ ref('snowplow_normalize_base_events_this_run') }}
 where
     event_name = '{{ event_name }}'
-    {% if not test %}
+    {% if not remove_new_event_check %}
         and {{ snowplow_utils.is_run_with_new_events("snowplow_normalize") }}
     {%- endif -%}
 {% endmacro %}

--- a/macros/schema.yml
+++ b/macros/schema.yml
@@ -31,9 +31,9 @@ macros:
       - name: context_aliases
         type: array
         description: List of prefixes to apply to the respective context column keys to be used as final column names
-      - name: test
+      - name: remove_new_event_check
         type: boolean
-        description: A flag to disable the `with_new_events` part of the macro to allow for integration tests to run
+        description: A flag to disable the `with_new_events` part of the macro, to allow for integration tests to run
   - name: users_table
     description: A macro to produce a users table from the `base_events_this_run` table, using the latest context values as defined by the collector_tstamp.
     arguments:
@@ -46,3 +46,6 @@ macros:
       - name: user_types
         type: array of arrays
         description: List of list of types of the values of the keys within the respective user context column (only used in Snowflake)
+      - name: remove_new_event_check
+        type: boolean
+        description: A flag to disable the `with_new_events` part of the macro, to allow for integration tests to run

--- a/macros/schema.yml
+++ b/macros/schema.yml
@@ -31,6 +31,9 @@ macros:
       - name: context_aliases
         type: array
         description: List of prefixes to apply to the respective context column keys to be used as final column names
+      - name: test
+        type: boolean
+        description: A flag to disable the `with_new_events` part of the macro to allow for integration tests to run
   - name: users_table
     description: A macro to produce a users table from the `base_events_this_run` table, using the latest context values as defined by the collector_tstamp.
     arguments:

--- a/macros/users_table.sql
+++ b/macros/users_table.sql
@@ -1,8 +1,8 @@
-{% macro users_table(user_cols = [], user_keys = [], user_types = [], test = false) %}
-    {{ return(adapter.dispatch('users_table', 'snowplow_normalize')(user_cols, user_keys, user_types, test)) }}
+{% macro users_table(user_cols = [], user_keys = [], user_types = [], remove_new_event_check = false) %}
+    {{ return(adapter.dispatch('users_table', 'snowplow_normalize')(user_cols, user_keys, user_types, remove_new_event_check)) }}
 {% endmacro %}
 
-{% macro snowflake__users_table(user_cols, user_keys, user_types, test) %}
+{% macro snowflake__users_table(user_cols, user_keys, user_types, remove_new_event_check) %}
 {# Remove down to major version for Snowflake columns, drop 2 last _X values #}
 {%- set user_cols_clean = [] -%}
 {%- for ind in range(user_cols|length) -%}
@@ -25,7 +25,7 @@ from
     {{ ref('snowplow_normalize_base_events_this_run') }}
 where
     user_id is not null
-    {% if not test %}
+    {% if not remove_new_event_check %}
         and {{ snowplow_utils.is_run_with_new_events("snowplow_normalize") }}
     {%- endif -%}
 qualify
@@ -33,7 +33,7 @@ qualify
 {% endmacro %}
 
 
-{% macro bigquery__users_table(user_cols, user_keys, user_types, test) %}
+{% macro bigquery__users_table(user_cols, user_keys, user_types, remove_new_event_check) %}
 {# Replace keys with snake_case where needed #}
 {%- set user_keys_clean = [] -%}
 {%- for ind1 in range(user_keys|length) -%}
@@ -62,7 +62,7 @@ from
     {{ ref('snowplow_normalize_base_events_this_run') }}
 where
     user_id is not null
-    {% if not test %}
+    {% if not remove_new_event_check %}
         and {{ snowplow_utils.is_run_with_new_events("snowplow_normalize") }}
     {%- endif -%}
 )
@@ -75,7 +75,7 @@ where
     rn = 1
 {% endmacro %}
 
-{% macro databricks__users_table(user_cols, user_keys, user_types, test) %}
+{% macro databricks__users_table(user_cols, user_keys, user_types, remove_new_event_check) %}
 {# Remove down to major version for Databricks columns, drop 2 last _X values #}
 {%- set user_cols_clean = [] -%}
 {%- for ind in range(user_cols|length) -%}
@@ -114,7 +114,7 @@ from
     {{ ref('snowplow_normalize_base_events_this_run') }}
 where
     user_id is not null
-    {% if not test %}
+    {% if not remove_new_event_check %}
         and {{ snowplow_utils.is_run_with_new_events("snowplow_normalize") }}
     {%- endif -%}
 )


### PR DESCRIPTION
## Description & motivation
The goal of this PR is to add a suite of basic unit tests for the macros in the package to ensure they correctly return expected SQL for the various warehouses. This adds a new argument to the functions that exists simply to avoid having to call the `is_run_with_new_events` macros and allows me to delay adding seeds and proper on-db integration tests to the package (which will be required for bigquery colum combination).

The focus of this was giving dummy inputs that are easier to debug, rather than test the full processing of full snowplow data.

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have raised a [documentation](https://github.com/snowplow/documentation) PR if applicable (N/A)
