### PR TITLE
Hotfix for problem with new BQ loader with shorter col names

### DIFF
--- a/macros/normalize_events.sql
+++ b/macros/normalize_events.sql
@@ -65,10 +65,14 @@ where
 
 
 {% macro bigquery__normalize_events(event_names, flat_cols = [], sde_cols = [], sde_keys = [], sde_types = [], sde_aliases = [], context_cols = [], context_keys = [], context_types = [], context_aliases = [], remove_new_event_check = false) %}
-{# Remove down to major version for bigquery combine columns macro, drop 2 last _X values #}
+{# For old version of BQ loader: Remove down to major version for bigquery combine columns macro, drop 2 last _X values. Otherwise keep it as is #}
 {%- set sde_cols_clean = [] -%}
 {%- for ind in range(sde_cols|length) -%}
-    {% do sde_cols_clean.append('_'.join(sde_cols[ind].split('_')[:-2])) -%}
+    {% if sde_cols[ind].split('_')[-2].isnumeric() and sde_cols[ind].split('_')[-1].isnumeric() %}
+        {% do sde_cols_clean.append('_'.join(sde_cols[ind].split('_')[:-2])) %}
+    {% else %}
+        {% do sde_cols_clean.append(sde_cols[ind]) %}
+    {% endif %}
 {%- endfor -%}
 {%- set context_cols_clean = [] -%}
 {%- for ind in range(context_cols|length) -%}


### PR DESCRIPTION
## Description & motivation
When we have implemented the new BQ loader that has similar style to other warehouses with cols named like `my_schema_1` and not `my_schema_1_0_0`, the built in logic of normalize broke. This is a simple fix to the problem but should probably be handled better to account for all changes. We have further problems as well but most of these can be fixed with custom scripts etc.

Please chime in with comments or other suggestions. We really like the normalize package

## Checklist
- [X] I have verified that these changes work locally
- [N/A] I have updated the README.md (if applicable)
- [N/A] I have added tests & descriptions to my models (and macros if applicable)
- [N/A] I have raised a [documentation](https://github.com/snowplow/documentation) PR if applicable (Link here if required)
