### PR TITLE
Fix/ci workflow aws assumed role spark and certifi

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -7,7 +7,17 @@ on:
       - 'release/**'
 concurrency: dbt_integration_tests
 
+
+permissions:
+  id-token: write   # This is required for requesting the JWT
+
+
 env:
+
+  # Set AWS Role
+  AWS_REGION : "eu-west-1"
+  AWS_ROLE_ARN: "arn:aws:iam::719197435995:role/DbtSparkTestingActions"
+
   # Set profiles.yml directory
   DBT_PROFILES_DIR: ./ci
 
@@ -75,12 +85,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_SNOWPLOWCI_READ_USERNAME }}
           password: ${{ secrets.DOCKERHUB_SNOWPLOWCI_READ_PASSWORD }}
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: eu-west-1
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          role-session-name: dbt-pr-tests-${{ github.run_number }}
+          aws-region: ${{ env.AWS_REGION }}
       - name: Set warehouse variables
         id: set_warehouse
         run: |

--- a/.github/workflows/publish-gh-pages.yml
+++ b/.github/workflows/publish-gh-pages.yml
@@ -99,7 +99,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install --upgrade pip wheel setuptools
-        pip install -Iv dbt-${{ matrix.warehouse }}==${{ matrix.dbt_version }} --upgrade
+        pip install -Iv certifi==2025.1.31 dbt-${{ matrix.warehouse }}==${{ matrix.dbt_version }} --upgrade
         dbt deps
 
     - name: Create dbt docs

--- a/.github/workflows/spark_deployment/docker-compose.yml
+++ b/.github/workflows/spark_deployment/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       - SPARK_MASTER_OPTS="-Dspark.driver.memory=2g"
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+      - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}
       - AWS_REGION=eu-west-1
       - AWS_DEFAULT_REGION=eu-west-1
     volumes:
@@ -39,6 +40,7 @@ services:
       - SPARK_MASTER=spark://spark-master:7077
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+      - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}
       - AWS_REGION=eu-west-1
       - AWS_DEFAULT_REGION=eu-west-1
     volumes:
@@ -58,6 +60,7 @@ services:
       - SPARK_LOCAL_IP=thrift-server
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+      - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}
       - AWS_REGION=eu-west-1
       - AWS_DEFAULT_REGION=eu-west-1
     volumes:

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
## Description & motivation
This pull request introduces updates to use role-based AWS authentication, adding session tokens to Docker Compose services, and downgrading Python dependencies in the publishing workflow as a workaround for certificate errors when using the Snowflake Python connector to interact with AWS S3: https://status.snowflake.com/incidents/txclg2cyzq32

Also fixes The “[Python Unit Tests](https://github.com/snowplow/dbt-snowplow-normalize/blob/main/.github/workflows/unit_test.yml)” actions workflow. The current “latest” ubuntu version is 24.04 and the “Python Unit Tests” workflow was developed when the latest ubuntu ver was 22.04. See failure logs [here](https://github.com/snowplow/dbt-snowplow-normalize/actions/runs/16596488342/job/46944300558).

As ubuntu ver 24.04 no longer has python versions 3.7 and 3.8, and the workflow tries to set it up, failure happens. Removed python versions 3.7 and 3.8 from the matrix. Add 3.11 and 3.12. Continue to use ubuntu ver 24.04. See [here](https://github.com/actions/runner-images/issues/10636).

## Checklist
- [ ] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have raised a [documentation](https://github.com/snowplow/documentation) PR if applicable (Link here if required)

<!-- 
## Release Only Checklist
- [ ] I have updated the version number in all relevant places
- [ ] I have updated the CHANGELOG.md 
-->
