### PR TITLE
Release/snowplow normalize/0.4.1

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -8,10 +8,10 @@ on:
 jobs:
   build:
     name: Run Python Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v3

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,17 @@
+Snowplow Normalize 0.4.1 (2025-07-30)
+---------------------------------------
+## Summary
+This release introduces the requirement for the user to explicitly accept the snowplow user license.
+
+## Features
+- A new boolean variable `snowplow__license_accepted` has been introduced in the main dbt package's `dbt_project.yml` file.
+- The default value of variable `snowplow__license_accepted` has been set to `false`.
+- To use this dbt package, the user is required accept the Snowplow Personal and Academic License or have a commercial agreement with Snowplow. See: https://docs.snowplow.io/personal-and-academic-license-1.0.
+- To accept, the user needs to set variable `snowplow__license_accepted` to `true` in their project's `dbt_project.yml`.
+
+## Upgrading
+To upgrade simply bump the snowplow-normalize version in your `packages.yml` file.
+
 Snowplow Normalize 0.4.0 (2024-12-04)
 ---------------------------------------
 ## Summary

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,6 +1,6 @@
 
 name: 'snowplow_normalize'
-version: '0.4.0'
+version: '0.4.1'
 config-version: 2
 
 require-dbt-version: [">=1.4.0", "<2.0.0"]

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -29,6 +29,7 @@ vars:
     snowplow__grant_select_to: []
     snowplow__grant_schema_usage: true
     # Variables - Standard Config
+    snowplow__license_accepted: false
     snowplow__start_date: '2020-01-01'
     snowplow__backfill_limit_days: 30
     snowplow__app_id: []
@@ -51,6 +52,7 @@ vars:
 
 # Completely or partially remove models from the manifest during run start.
 on-run-start:
+  - "{{ snowplow_utils.license_check(var('snowplow__license_accepted')) }}"
   - "{{ snowplow_utils.snowplow_delete_from_manifest(var('models_to_remove',[]), ref('snowplow_normalize_incremental_manifest')) }}"
 
 # Update manifest table with last event consumed per sucessfully executed node/model

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'snowplow_normalize_integration_tests'
-version: '0.4.0'
+version: '0.4.1'
 config-version: 2
 
 profile: 'integration_tests'

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -28,6 +28,8 @@ quoting:
 
 
 vars:
+  snowplow__license_accepted: true
+  
   snowplow_normalize:
     snowplow__events: "{{ ref('snowplow_normalize_stg') }}"
     snowplow__start_date: "2022-10-01"

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: snowplow/snowplow_utils
-    version: [">=0.17.0", "<0.18.0"]
+    version: [">=0.17.3", "<0.18.0"]


### PR DESCRIPTION
## Description & motivation
Introduces the requirement for the user to explicitly accept the snowplow user license.

- A new boolean variable `snowplow__license_accepted` has been introduced in the main dbt package's `dbt_project.yml` file.
- The default value of variable `snowplow__license_accepted` has been set to `false`.
- To use this dbt package, the user is required accept the Snowplow Personal and Academic License or have a commercial agreement with Snowplow. See: https://docs.snowplow.io/personal-and-academic-license-1.0.
- To accept, set the main dbt project's `dbt_project.yml` variable `snowplow__license_accepted` to `true`.

**_Also fixes the python unit-test failure as described here:_** https://snplow.atlassian.net/browse/AISP-648

## Checklist
- [ ] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have raised a [documentation](https://github.com/snowplow/documentation) PR if applicable (Link here if required)

<!-- 
## Release Only Checklist
- [ ] I have updated the version number in all relevant places
- [ ] I have updated the CHANGELOG.md 
-->
