### PR TITLE
Restrict pr_tests workflow

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -65,6 +65,7 @@ env:
 jobs:
   pr_tests:
     name: pr_tests
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
## Description
Preventing the pr_tests CI workflow from running on pull requests opened from a fork 
against this repo, ensuring CI only runs using this repo's credentials. Contributors can still run CI within their own fork using their own credentials.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [x] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Checklist
- [ ] 💣 Is your change a breaking change?
- [ ] 📖 I have updated the CHANGELOG.md

### Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
